### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,21 @@
 To view usage documentation, head over to [https://enterprise.coder.com](https://enterprise.coder.com/docs/getting-started).
 
 To report bugs and request features, please [open an issue](https://github.com/cdr/coder-cli/issues/new).
+
+## Installation
+
+To install the latest version use:
+
+```bash
+go get cdr.dev/coder-cli/cmd/coder
+```
+
+To install a specific [release](https://github.com/cdr/coder-cli/releases):
+
+1. Click a release and download the tar file for your operating system (ex: coder-cli-linux-amd64.tar.gz)
+2. Extract the `coder` binary from the tar file, ex:
+
+```bash
+cd ~/go/bin
+tar -xvf ~/Downloads/coder-cli-linux-amd64.tar.gz
+```


### PR DESCRIPTION
Currently, we link to this readme from enterprise documentation, but we do not have any installation instructions:

![Screenshot from 2020-06-10 07-34-56](https://user-images.githubusercontent.com/11184711/84268202-e8070780-aaec-11ea-9d46-263e32d47732.png)
