### PR TITLE
feat: Allow setting workspace thresholds from the api

### DIFF
--- a/coder-sdk/org.go
+++ b/coder-sdk/org.go
@@ -72,6 +72,7 @@ type UpdateOrganizationReq struct {
 	AutoOffThreshold       *Duration `json:"auto_off_threshold"`
 	CPUProvisioningRate    *float32  `json:"cpu_provisioning_rate"`
 	MemoryProvisioningRate *float32  `json:"memory_provisioning_rate"`
+	AllowWorkspaceAutoOff  *bool     `json:"workspace_auto_off"`
 }
 
 // UpdateOrganization applys a partial update of an Organization resource.

--- a/coder-sdk/workspace.go
+++ b/coder-sdk/workspace.go
@@ -89,6 +89,9 @@ type CreateWorkspaceRequest struct {
 	Namespace       string  `json:"namespace"`
 	EnableAutoStart bool    `json:"autostart_enabled"`
 
+	// WorkspaceAutoOffThreshold is optional, 0 defaults to the org settings
+	WorkspaceAutoOffThreshold Duration `json:"workspace_auto_off_threshold"`
+
 	// ForUserID is an optional param to create a workspace for another user
 	// other than the requester. This only works for admins and site managers.
 	ForUserID string `json:"for_user_id,omitempty"`

--- a/coder-sdk/workspace.go
+++ b/coder-sdk/workspace.go
@@ -211,13 +211,14 @@ func (c *DefaultClient) StopWorkspace(ctx context.Context, workspaceID string) e
 // UpdateWorkspaceReq defines the update operation, only setting
 // nil-fields.
 type UpdateWorkspaceReq struct {
-	ImageID    *string  `json:"image_id"`
-	ImageTag   *string  `json:"image_tag"`
-	CPUCores   *float32 `json:"cpu_cores"`
-	MemoryGB   *float32 `json:"memory_gb"`
-	DiskGB     *int     `json:"disk_gb"`
-	GPUs       *int     `json:"gpus"`
-	TemplateID *string  `json:"template_id"`
+	ImageID                   *string   `json:"image_id"`
+	ImageTag                  *string   `json:"image_tag"`
+	CPUCores                  *float32  `json:"cpu_cores"`
+	MemoryGB                  *float32  `json:"memory_gb"`
+	DiskGB                    *int      `json:"disk_gb"`
+	GPUs                      *int      `json:"gpus"`
+	TemplateID                *string   `json:"template_id"`
+	WorkspaceAutoOffThreshold *Duration `json:"workspace_auto_off_threshold"`
 }
 
 // RebuildWorkspace requests that the given workspaceID is rebuilt with no changes to its specification.

--- a/internal/cmd/workspaces.go
+++ b/internal/cmd/workspaces.go
@@ -397,7 +397,8 @@ func createWorkspaceCmd() *cobra.Command {
 		useCVM          bool
 		providerName    string
 		enableAutostart bool
-		forUser         string // Optional
+		forUser         string        // Optional
+		autoOffDuration time.Duration // Optional
 	)
 
 	cmd := &cobra.Command{
@@ -468,19 +469,20 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 
 			// ExactArgs(1) ensures our name value can't panic on an out of bounds.
 			createReq := &coder.CreateWorkspaceRequest{
-				Name:            args[0],
-				ImageID:         importedImg.ID,
-				OrgID:           importedImg.OrganizationID,
-				ImageTag:        tag,
-				CPUCores:        cpu,
-				MemoryGB:        memory,
-				DiskGB:          disk,
-				GPUs:            gpus,
-				UseContainerVM:  useCVM,
-				ResourcePoolID:  provider.ID,
-				Namespace:       provider.DefaultNamespace,
-				EnableAutoStart: enableAutostart,
-				ForUserID:       forUser,
+				Name:                      args[0],
+				ImageID:                   importedImg.ID,
+				OrgID:                     importedImg.OrganizationID,
+				ImageTag:                  tag,
+				CPUCores:                  cpu,
+				MemoryGB:                  memory,
+				DiskGB:                    disk,
+				GPUs:                      gpus,
+				UseContainerVM:            useCVM,
+				ResourcePoolID:            provider.ID,
+				Namespace:                 provider.DefaultNamespace,
+				EnableAutoStart:           enableAutostart,
+				ForUserID:                 forUser,
+				WorkspaceAutoOffThreshold: coder.Duration(autoOffDuration),
 			}
 
 			// if any of these defaulted to their zero value we provision
@@ -519,6 +521,8 @@ coder workspaces create my-new-powerful-workspace --cpu 12 --disk 100 --memory 1
 			return nil
 		},
 	}
+	cmd.Flags().DurationVar(&autoOffDuration, "auto-off", 0, "Sets the workspace's auto-off setting. This only works if the organization has this feature enabled. "+
+		"Set to '-1' to disable auto-off, and '0' to default to the organization's setting.")
 	cmd.Flags().StringVarP(&org, "org", "o", "", "name of the organization the workspace should be created under.")
 	cmd.Flags().StringVarP(&tag, "tag", "t", defaultImgTag, "tag of the image the workspace will be based off of.")
 	cmd.Flags().Float32VarP(&cpu, "cpu", "c", 0, "number of cpu cores the workspace should be provisioned with.")


### PR DESCRIPTION
# What this does

Adds a `--auto-off` to `envs edit` and `envs create` to set auto off on a per workspace basis

```
coder envs create autooff --auto-off=1m --image ubuntu

coder envs edit ubuntu --auto-off=5m 
```