### PR TITLE
feat(cli): compare hotfix version metadata

### DIFF
--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -230,7 +230,7 @@ func (u *updater) Run(ctx context.Context, force bool, coderURLArg string, versi
 		return clog.Fatal("failed to update coder binary", clog.Causef(err.Error()))
 	}
 
-	clog.LogSuccess("Updated coder CLI to version " + desiredVersion.String())
+	clog.LogSuccess("Updated coder CLI")
 	return nil
 }
 

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -153,7 +153,7 @@ func (u *updater) Run(ctx context.Context, force bool, coderURLArg string, versi
 		}
 		hotfix := ""
 		if hotfixVersion(desiredVersion) != "" {
-			hotfix = "+" + hotfixVersion(desiredVersion)
+			hotfix = hotfixVersion(desiredVersion)
 		}
 		label := fmt.Sprintf("Do you want to download version %d.%d.%d%s%s instead",
 			desiredVersion.Major(),


### PR DESCRIPTION
This PR allows specifying `cli.N` hotfix versions to download.
Also altered the success message to remove redundant information.

*Before:*
```
$ ./coder update --version v1.19.0+cli.1                                                                                                                                                                                                                                                                                                                                                                                 
info: Current version of coder-cli is "v2.34.5"                                                                                                                                                                                                                                                                                                                                                                           
? Do you want to download version 1.19.0 instead? [y/N] y                                                                                                                                                                                                                                                                                                                                                                
info: query github releases                                                                                                                                                                                                                                                                                                                                                                                               
  | url: "https://api.github.com/repos/cdr/coder-cli/releases/tags/v1.19.0"                                                                                                                                                                                                                                                                                                                                               
info: fetching coder-cli from GitHub releases
  | https://github.com/cdr/coder-cli/releases/download/v1.19.0/coder-cli-linux-amd64.tar.gz
info: updated binary reports "coder version v1.19.0 go1.16.4 linux/amd64"
success: Updated coder CLI to version 1.19.0+cli.1
```

*After:*
```
$ ./coder update --version v1.19.0+cli.1
info: Current version of coder-cli is "v2.34.5"
Do you want to download version 1.19.0++cli.1 instead: y
info: query github releases
  | url: "https://api.github.com/repos/cdr/coder-cli/releases/tags/v1.19.0+cli.1"
info: fetching coder-cli from GitHub releases
  | https://github.com/cdr/coder-cli/releases/download/v1.19.0%2Bcli.1/coder-cli-linux-amd64.tar.gz
info: updated binary reports "coder version v1.19.0+cli.1 go1.16.4 linux/amd64"
success: Updated coder CLI
```