### PR TITLE
add: coder tunnel docs & coder users ls flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub Release](https://img.shields.io/github/v/release/cdr/coder-cli?color=6b9ded&include_prerelease=false)](https://github.com/cdr/coder-cli/releases)
 [![Documentation](https://godoc.org/cdr.dev/coder-cli?status.svg)](https://pkg.go.dev/cdr.dev/coder-cli/coder-sdk)
 
-> **Note**: This is the command line utility for [Coder Classic](https://coder.com/docs/coder).
+> **Note**: This is the command line utility for [Coder v1](https://coder.com/docs/coder).
 > If you are using [Coder OSS](https://coder.com/docs/coder-oss/latest), use [these instructions](https://coder.com/docs/coder-oss/latest/install)
 > to install the CLI.
 

--- a/docs/coder_tunnel.md
+++ b/docs/coder_tunnel.md
@@ -1,0 +1,35 @@
+## coder tunnel
+
+proxies a port on the workspace to localhost
+
+```console
+  coder tunnel [workspace_name] [workspace_port] [localhost_port] [flags]
+```
+
+### Examples
+
+```console
+# run a tcp tunnel from the workspace on port 3000 to localhost:3000
+coder tunnel my-dev 3000 3000
+
+# run a udp tunnel from the workspace on port 53 to localhost:53
+coder tunnel --udp my-dev 53 53
+```
+
+### Options
+
+```console
+      --address string                local address to bind to (default "127.0.0.1")
+  -h, --help                          help for tunnel
+      --max-retry-duration duration   maximum amount of time to sleep between retry attempts (default 1m0s)
+      --retry int                     number of attempts to retry if the tunnel fails to establish or disconnect (-1 for infinite retries)
+      --udp                           tunnel over UDP instead of TCP
+```
+
+### Options inherited from parent commands
+
+```console
+      --coder-token string   API authentication token.
+      --coder-url string     access url of the Coder deployment. (default "https://demo-2.cdr.dev")
+  -v, --verbose              show verbose output (also settable via CODER_AGENT_VERBOSE) (default true)
+```

--- a/docs/coder_users_ls.md
+++ b/docs/coder_users_ls.md
@@ -2,31 +2,35 @@
 
 list all user accounts
 
-```
+```console
 coder users ls [flags]
 ```
 
 ### Examples
 
-```
+```console
 coder users ls -o json
 coder users ls -o json | jq .[] | jq -r .email
 ```
 
 ### Options
 
-```
+```console
+      --after string    returns users in the list after the specified ID
+      --before string   returns users in the list before the specified ID
   -h, --help            help for ls
+      --limit int       maximum number of users to return (default 100)
   -o, --output string   human | json (default "human")
 ```
 
 ### Options inherited from parent commands
 
-```
+```console
+      --coder-token string   API authentication token.
+      --coder-url string     access url of the Coder deployment. (default "https://demo-2.cdr.dev")
   -v, --verbose   show verbose output
 ```
 
 ### SEE ALSO
 
-* [coder users](coder_users.md)	 - Interact with Coder user accounts
-
+* [coder users](coder_users.md) - Interact with Coder user accounts


### PR DESCRIPTION
adds missing flags to our `coder users ls` docs ([see here](https://github.com/coder/v1/issues/13126)), and also adds docs for `coder tunnel`.